### PR TITLE
chore: add terramate vendor manifest

### DIFF
--- a/.terramate/manifest.tm.hcl
+++ b/.terramate/manifest.tm.hcl
@@ -1,0 +1,11 @@
+vendor {
+  manifest {
+    default {
+      files = [
+        "/*.tf",
+        "/README.*",
+        "LICENSE",
+      ]
+    }
+  }
+}


### PR DESCRIPTION
The behavior can be tested by installing a specific Terramate version (work still on a branch):

```sh
go install github.com/mineiros-io/terramate/cmd/terramate@katcipis-vendor-manifest
```

And then running:

```sh
terramate experimental vendor download github.com/mineiros-io/terraform-google-pubsub-topic katcipis-add-vendor-manifest
```

Right now it only copies the tf code and README/LICENSE, but maybe we want something else vendored.